### PR TITLE
Added one file to set environmental variables 

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,12 @@ Confirm that installation works
 conda activate {env_name}
 nextstrain check-setup --set-default
 ```
-Set environment variable `GEN3_API_KEY`. The PRC credentials (json format) can be downloaded from the profile page after Login to [PRC data commons](https://chicagoland.pandemicresponsecommons.org/).
+Edit file of `set_env_var.sh` and add the path of PRC credentials to the variable `GEN3_API_KEY`. The PRC credentials (json format) can be downloaded from the profile page after Login to [PRC data commons](https://chicagoland.pandemicresponsecommons.org/). After saving the file, run the command line below.
 ```
-export GEN3_API_KEY={path_to_local_PRC_credential_json}
+source set_env_var.sh
 # To confirm env variable
 echo $GEN3_API_KEY
+echo $project_id
 ```
 ## Run analysis workflow
 To get the phylogenetic tree including all Illinois covid19 strains hosted at PRC data commons. Simply run

--- a/set_env_var.sh
+++ b/set_env_var.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export GEN3_API_KEY=
+export project_id="Walder-SIU-SARS-CoV2"


### PR DESCRIPTION
Running gen3-augur requires two environmental variables for query purpose. 

